### PR TITLE
Transaction ID fix

### DIFF
--- a/src/CommunityStore/Payment/Methods/CommunityStoreSquare/CommunityStoreSquarePaymentMethod.php
+++ b/src/CommunityStore/Payment/Methods/CommunityStoreSquare/CommunityStoreSquarePaymentMethod.php
@@ -36,8 +36,9 @@ class CommunityStoreSquarePaymentMethod extends StorePaymentMethod
         $this->set('squareGateways',$gateways);
 
         $currencies = array(
-        	'USD'=>t('US Dollars'),
-        	'CAD'=>t('Canadian Dollar')
+        	'AUD'=>t('Australian Dollar'),
+		'CAD'=>t('Canadian Dollar'),
+		'USD'=>t('US Dollar')
         );
 
         $this->set('squareCurrencies',$currencies);

--- a/src/CommunityStore/Payment/Methods/CommunityStoreSquare/CommunityStoreSquarePaymentMethod.php
+++ b/src/CommunityStore/Payment/Methods/CommunityStoreSquare/CommunityStoreSquarePaymentMethod.php
@@ -137,9 +137,11 @@ class CommunityStoreSquarePaymentMethod extends StorePaymentMethod
 
         // Alert for debugging purposes only
         Log::addEntry('Square info.'."\n".'Result is:' . $result . "\n", t('Community Store Square'));
+	
+	$result = json_decode($result);
 
         // credit card payment was successful - updating database - order record
-        return array('error'=>0, 'transactionReference'=>$result);
+        return array('error'=>0, 'transactionReference'=>$result->transaction->id);
   		} catch (\SquareConnect\ApiException $e) {
         $respBody = $e->getResponseBody();
         if (is_object($respBody)) {


### PR DESCRIPTION
This PR fixes an issue where the entire JSON response from the gateway is being used as the transaction ID - this instead extracts just the transaction ID and uses that.

It also sneaks in an update to include AUD as a currency option.  :-)